### PR TITLE
Use older version of cake

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.23.0-alpha0059" />
+    <package id="Cake" version="0.21.1" />
 </packages>


### PR DESCRIPTION
Cake.Recipe currently doesn't support v0.22.0+ of cake.exe
This should fix the issue with the Deploy-Graph-Documentation step